### PR TITLE
Make `npm run` respect silent

### DIFF
--- a/hook
+++ b/hook
@@ -152,7 +152,7 @@ function run(status, err, output) {
       task = run.shift();
       if (!task) return done();
 
-      var npm = child.spawn('npm', ['run', task], {
+      var npm = child.spawn('npm', ['run', task, silent ? '--silent' : ''], {
         cwd: root,            // Make sure that we spawn it in the root of repo.
         env: process.env,     // Give them the same ENV variables.
         stdio: [0, 1, 2]      // Pipe all the things.


### PR DESCRIPTION
npm recently landed a commit to make `npm run` respect `--silent` ( https://github.com/npm/npm/commit/c95cf086e5b97dbb48ff95a72517b203a8f29eab ).

passing the flag to npm when silent is set in the package.json will reduce more even more output noise :)
