### PR TITLE
fix empty string bug

### DIFF
--- a/hook
+++ b/hook
@@ -151,8 +151,14 @@ function run(status, err, output) {
       // Check if we have tasks to be executed or if we are complete.
       task = run.shift();
       if (!task) return done();
+      
+      var args = ['run', task];
+      
+      if (silent) {
+        args.push('--silent');
+      }
 
-      var npm = child.spawn('npm', ['run', task, silent ? '--silent' : ''], {
+      var npm = child.spawn('npm', args, {
         cwd: root,            // Make sure that we spawn it in the root of repo.
         env: process.env,     // Give them the same ENV variables.
         stdio: [0, 1, 2]      // Pipe all the things.


### PR DESCRIPTION
My previous PR introduced an empty string bug.

It would `npm run test ''` which makes npm try to run empty string which fails terribly. It tries to run the command `''` for the local dependencies named `test`

For example `npm run tape test` would run tape tests.

This fixes the bug by never passing in `''`.

Please update & republish.

Either deprecate or unpublish 0.0.6

Apologies for introducing this bug.
