### PR TITLE
Remove peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "author": "Arnout Kazemier <opensource@observe.it>",
   "license": "MIT",
-  "peerDependencies": {
+  "dependencies": {
     "which": "1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Having a side effect of `npm i pre-commit -D` where it adds `which` as a dependency to my library is crazy.

Let's not use peer dependencies.