### PR TITLE
Bug fix

### DIFF
--- a/hook
+++ b/hook
@@ -6,11 +6,11 @@ IOJS=`which iojs 2> /dev/null`
 LOCAL="/usr/local/bin/node"
 
 if [[ -n $NODE ]]; then
-  $NODE $($NODE -e "console.log(require.resolve('pre-commit'))")
+  "$NODE" $("$NODE" -e "console.log(require.resolve('pre-commit'))")
 elif [[ -n $NODEJS ]]; then
-  $NODEJS $($NODEJS -e "console.log(require.resolve('pre-commit'))")
+  "$NODEJS" $("$NODEJS" -e "console.log(require.resolve('pre-commit'))")
 elif [[ -n $IOJS ]]; then
-  $IOJS $($IOJS -e "console.log(require.resolve('pre-commit'))")
+  "$IOJS" $("$IOJS" -e "console.log(require.resolve('pre-commit'))")
 elif [[ -x $LOCAL ]]; then
-  $LOCAL $($LOCAL -e "console.log(require.resolve('pre-commit'))")
+  "$LOCAL" $("$LOCAL" -e "console.log(require.resolve('pre-commit'))")
 fi


### PR DESCRIPTION
On Windows node sits in "C:\Program files\nodejs\" which has a space in it, so NODE has to be double quoted.