### PR TITLE
Adding path so pre-commit works well with source tree.

### DIFF
--- a/hook
+++ b/hook
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ~/.bash_profile
+
 NODE=`which node 2> /dev/null`
 NODEJS=`which nodejs 2> /dev/null`
 IOJS=`which iojs 2> /dev/null`


### PR DESCRIPTION
Pre-commit works great when committing from the command line but has some issues from Source Tree on OSX. As you can see on [Source Tree's website](https://answers.atlassian.com/questions/140339/sourcetree-hook-failing-because-paths-don-t-seem-to-be-set-correctly), this solution has been used by others with success. All unit tests passed on my local machine. Thanks for the great work!

@3rd-Eden @kriskowal @alexindigo @tikotzky @Qard 