### PR TITLE
Source .zshrc when .bash_profile isn't available

### DIFF
--- a/hook
+++ b/hook
@@ -4,12 +4,13 @@ HAS_NODE=`which node 2> /dev/null || which nodejs 2> /dev/null || which iojs 2> 
 
 #
 # There are some issues with Source Tree because paths are not set correctly for
-# the given environment. Sourcing the bash_profile seems to resolve this for users
+# the given environment. Sourcing the bash_profile seems to resolve this for bash users,
+# sourcing the zshrc for zshell users.
 #
 # https://answers.atlassian.com/questions/140339/sourcetree-hook-failing-because-paths-don-t-seem-to-be-set-correctly
 #
-if [ -z "$HAS_NODE" ] && [ -f ~/.bash_profile ]; then
-  source ~/.bash_profile
+if [[ -z "$HAS_NODE" ]]; then
+  source ~/.bash_profile || source ~/.zshrc || true
 fi
 
 NODE=`which node 2> /dev/null`

--- a/hook
+++ b/hook
@@ -9,8 +9,13 @@ HAS_NODE=`which node 2> /dev/null || which nodejs 2> /dev/null || which iojs 2> 
 #
 # https://answers.atlassian.com/questions/140339/sourcetree-hook-failing-because-paths-don-t-seem-to-be-set-correctly
 #
+function source_home_file {
+  file="$HOME/$1"
+  [[ -f "${file}" ]] && source "${file}"
+}
+
 if [[ -z "$HAS_NODE" ]]; then
-  source ~/.bash_profile || source ~/.zshrc || true
+  source_home_file ".bash_profile" || source_home_file ".zshrc" || true
 fi
 
 NODE=`which node 2> /dev/null`


### PR DESCRIPTION
I'm using the `zshell` (installed via [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)) and have no .bashrc/.bash_profile. So I'm sourcing the .zshrc instead and everything works fine.

Maybe it's worth to add it to the repo.