### PR TITLE
Make pre-commit hook symlink relative

### DIFF
--- a/install.js
+++ b/install.js
@@ -52,7 +52,7 @@ catch (e) {}
 // installation of this module to completely fail. We should just output the
 // error instead destroying the whole npm install process.
 //
-try { fs.symlinkSync(hook, precommit, 'file'); }
+try { fs.symlinkSync(path.relative(hooks, hook), precommit, 'file'); }
 catch (e) {
   console.error('pre-commit:');
   console.error('pre-commit: Failed to symlink the hook file in your .git/hooks folder because:');


### PR DESCRIPTION
Renaming or moving the project directory (the one containing .git) causes absolute links to break and the pre-commit hook to be silently ignored.  Instead, make the link relative so that it is preserved across directory rename/move.

Thanks,
Kevin