### PR TITLE
Support submodules

### DIFF
--- a/install.js
+++ b/install.js
@@ -8,6 +8,7 @@ var fs = require('fs')
   , spawn = require('cross-spawn')
   , hook = path.join(__dirname, 'hook')
   , root = path.resolve(__dirname, '..', '..')
+  , execSync = require('child_process').execSync
   , exists = fs.existsSync || path.existsSync;
 
 //
@@ -16,7 +17,9 @@ var fs = require('fs')
 // `pre-commit` file. The path needs to be absolute in order for the symlinking
 // to work correctly.
 //
-var git = path.resolve(root, '.git')
+
+var config = execSync('git rev-parse --git-dir', { cwd: root }).toString().trim()
+  , git = path.resolve(root, config)
   , hooks = path.resolve(git, 'hooks')
   , precommit = path.resolve(hooks, 'pre-commit');
 

--- a/uninstall.js
+++ b/uninstall.js
@@ -2,21 +2,24 @@
 
 var fs = require('fs')
   , path = require('path')
+  , execSync = require('child_process').execSync
   , exists = fs.existsSync || path.existsSync
-  , precommit = path.resolve(__dirname, '../..', '.git', 'hooks', 'pre-commit');
+  , root = path.resolve(__dirname, '..', '..')
+  , config = execSync('git rev-parse --git-dir', { cwd: root }).toString().trim()
+  , precommit = path.resolve(root, config, 'hooks', 'pre-commit');
 
 //
 // Bail out if we don't have pre-commit file, it might be removed manually.
 //
 if (!exists(precommit)) return;
 
+fs.unlinkSync(precommit);
+
 //
 // If we don't have an old file, we should just remove the pre-commit hook. But
 // if we do have an old precommit file we want to restore that.
 //
-if (!exists(precommit +'.old')) {
-  fs.unlinkSync(precommit);
-} else {
+if (exists(precommit +'.old')) {
   fs.writeFileSync(precommit, fs.readFileSync(precommit +'.old'));
   fs.chmodSync(precommit, '755');
   fs.unlinkSync(precommit +'.old');


### PR DESCRIPTION
 Submodule hooks are stored in `.git/modules/<submodule>/hooks` directory in parent repository.

This patch uses `git rev-parse --git-dir` to determine correct directory.