### PR TITLE
Update dep to remove warn about cross-spaw

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "cross-spawn": "^4.0.0",
+    "spawn-sync": "^1.0.15",
     "which": "1.2.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/observing/pre-commit",
   "license": "MIT",
   "dependencies": {
-    "cross-spawn": "2.0.x",
+    "cross-spawn": "^4.0.0",
     "which": "1.2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
With this the following warn is fixed

```
npm WARN deprecated cross-spawn-async@2.2.4: cross-spawn no longer requires a build toolchain, use it instead!
```