### PR TITLE
Fix pre-commit template

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ Hook.prototype.initialize = function initialize() {
   // execute.
   //
   if (this.config.template) {
-    this.exec(this.git, ['config', 'commit.template', '"'+ this.config.template +'"']);
+    this.exec(this.git, ['config', 'commit.template', this.config.template]);
   }
 
   if (!this.config.run) return this.log(Hook.log.run, 0);


### PR DESCRIPTION
Without this, it actually looks for a file with quotes around it on macOS and probably other platforms too.

The path is already escaped because it is part of an args array.
