### PR TITLE
Enable support for space-separated command chains

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,23 +219,20 @@ Hook.prototype.run = function runner() {
     var spawnConfig;
 
     // ES6 support
-    try {
-      spawnConfig = ['run', ...script.split(' '), '--silent'];
-    }
+    // spawnConfig = ['run', ...script.split(' '), '--silent'];
+
     // Legacy ES5 support
-    catch(err) {
-      spawnConfig = ['run'];
+    spawnConfig = ['run'];
 
-      if (~script.indexOf(' ')) {
-        script.split(' ').forEach(function(command) {
-          spawnConfig.push(command);
-        });
-      } else {
-        spawnConfig.push(script);
-      }
-
-      spawnConfig.push('--silent');
+    if (~script.indexOf(' ')) {
+      script.split(' ').forEach(function(command) {
+        spawnConfig.push(command);
+      });
+    } else {
+      spawnConfig.push(script);
     }
+
+    spawnConfig.push('--silent');
 
     //
     // There's a reason on why we're using an async `spawn` here instead of the

--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ Hook.prototype.run = function runner() {
     // this doesn't have the required `isAtty` information that libraries use to
     // output colors resulting in script output that doesn't have any color.
     //
-    spawn(hooked.npm, ['run', script, '--silent'], {
+    spawn(hooked.npm, ['run', ...script.split(' '), '--silent'], {
       env: process.env,
       cwd: hooked.root,
       stdio: [0, 1, 2]

--- a/index.js
+++ b/index.js
@@ -216,6 +216,26 @@ Hook.prototype.run = function runner() {
     if (!scripts.length) return hooked.exit(0);
 
     var script = scripts.shift();
+    var spawnConfig;
+
+    // ES6 support
+    try {
+      spawnConfig = ['run', ...script.split(' '), '--silent'];
+    }
+    // Legacy ES5 support
+    catch(err) {
+      spawnConfig = ['run'];
+
+      if (~script.indexOf(' ')) {
+        script.split(' ').forEach(function(command) {
+          spawnConfig.push(command);
+        });
+      } else {
+        spawnConfig.push(script);
+      }
+
+      spawnConfig.push('--silent');
+    }
 
     //
     // There's a reason on why we're using an async `spawn` here instead of the
@@ -225,7 +245,7 @@ Hook.prototype.run = function runner() {
     // this doesn't have the required `isAtty` information that libraries use to
     // output colors resulting in script output that doesn't have any color.
     //
-    spawn(hooked.npm, ['run', ...script.split(' '), '--silent'], {
+    spawn(hooked.npm, spawnConfig, {
       env: process.env,
       cwd: hooked.root,
       stdio: [0, 1, 2]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
     "example-fail": "echo \"This is the example hook, I exit with 1\" && exit 1",
+    "example fail": "echo \"This is the example hook, I exit with 1\" && exit 1",
     "example-pass": "echo \"This is the example hook, I exit with 0\" && exit 0",
     "install": "node install.js",
     "test": "mocha test.js",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "assume": "1.4.x",
     "istanbul": "0.4.x",
     "mocha": "~3.2.0",
-    "pre-commit": "git://github.com/observing/pre-commit.git"
+    "pre-commit": "git://github.com/observing/pre-commit.git",
+    "thread-sleep": "1.0.4"
   }
 }

--- a/test.js
+++ b/test.js
@@ -253,5 +253,16 @@ describe('pre-commit', function () {
       hook.config.run = ['example-fail'];
       hook.run();
     });
+
+    it('runs the specified test with spaces and exits with 1 on error', function (next) {
+      var hook = new Hook(function (code, lines) {
+        assume(code).equals(1);
+
+        next();
+      }, { ignorestatus: true });
+
+      hook.config.run = ['example-fail'];
+      hook.run();
+    });
   });
 });


### PR DESCRIPTION
When using external scripts such as [Package-Scripts](https://github.com/kentcdodds/p-s), we need to provide the command chain as a space-separated string. (e.g. npm start lint-scripts)

To support that kind of syntax, I've added some logic that a space-separated string is spread as separate properties in the spawn array.

This does not conflict with a space-separated package script name that, although it is valid JSON, will not run when using "npm run xxx".