### PR TITLE
Allow skipping invocation of `npm` binary

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,6 +216,12 @@ Hook.prototype.run = function runner() {
     if (!scripts.length) return hooked.exit(0);
 
     var script = scripts.shift();
+    var cmd = hooked.npm;
+    var args = ['run', script, '--silent'];
+    if (!hooked.config.npm) {
+      cmd = './node_modules/.bin/' + script;
+      args = [];
+    }
 
     //
     // There's a reason on why we're using an async `spawn` here instead of the
@@ -225,7 +231,7 @@ Hook.prototype.run = function runner() {
     // this doesn't have the required `isAtty` information that libraries use to
     // output colors resulting in script output that doesn't have any color.
     //
-    spawn(hooked.npm, ['run', script, '--silent'], {
+    spawn(cmd, args, {
       env: process.env,
       cwd: hooked.root,
       stdio: [0, 1, 2]


### PR DESCRIPTION
An attempt at #93.

I'm not sure if this is an optimal solution, but this allows you to define `"npm": false` in your pre-commit config to skip invoking npm's binary.

Instead, the current implementation simply takes the cmd name as `./node_modules/.bin/$cmd` and runs it. 

I suppose that this should use `which` to look for the binary before running it, which I can do if you'd prefer.

I'm also not sure if/how you'd like this tested, so all I've done is ensure that it works on my project.

Example:

```json
"pre-commit": {
    "npm": false,
    "run": "lint-staged"
},
```