### PR TITLE
Support for git repos as submodules

### DIFF
--- a/install.js
+++ b/install.js
@@ -21,6 +21,21 @@ var git = path.resolve(root, '.git')
   , precommit = path.resolve(hooks, 'pre-commit');
 
 //
+// Resolve git directory for submodules
+//
+if (exists(git) && fs.lstatSync(git).isFile()) {
+  var gitinfo = fs.readFileSync(git).toString()
+    , gitdirmatch = /gitdir: (.+)/.exec(gitinfo)
+    , gitdir = gitdirmatch.length == 2 ? gitdirmatch[1] : null;
+
+  if (gitdir !== null) {
+    git = path.resolve(root, gitdir);
+    hooks = path.resolve(git, 'hooks');
+    precommit = path.resolve(hooks, 'pre-commit');
+  }
+}
+
+//
 // Bail out if we don't have an `.git` directory as the hooks will not get
 // triggered. If we do have directory create a hooks folder if it doesn't exist.
 //

--- a/uninstall.js
+++ b/uninstall.js
@@ -3,7 +3,26 @@
 var fs = require('fs')
   , path = require('path')
   , exists = fs.existsSync || path.existsSync
-  , precommit = path.resolve(__dirname, '../..', '.git', 'hooks', 'pre-commit');
+  , root = path.resolve(__dirname, '..', '..')
+  , git = path.resolve(root, '.git');
+
+//
+// Resolve git directory for submodules
+//
+if (exists(git) && fs.lstatSync(git).isFile()) {
+  var gitinfo = fs.readFileSync(git).toString()
+    , gitdirmatch = /gitdir: (.+)/.exec(gitinfo)
+    , gitdir = gitdirmatch.length == 2 ? gitdirmatch[1] : null;
+
+  if (gitdir !== null) {
+    git = path.resolve(root, gitdir);
+  }
+}
+
+//
+// Location of pre-commit hook, if it exists
+//
+var precommit = path.resolve(git, 'hooks', 'pre-commit');
 
 //
 // Bail out if we don't have pre-commit file, it might be removed manually.


### PR DESCRIPTION
If a git repo is setup as a submodule of another repo, `.git` is a file (rather than a directory) containing the path to the submodule's git directory within the parent repos `.git` directory. This PR just adds the ability, if `.git` is a file, to resolve the actual git directory and install/uninstall to the right location.