### PR TITLE
Changing git path handling when the git is a submodule

### DIFF
--- a/install.js
+++ b/install.js
@@ -20,6 +20,17 @@ var git = path.resolve(root, '.git')
   , hooks = path.resolve(git, 'hooks')
   , precommit = path.resolve(hooks, 'pre-commit');
 
+// If the .git is a file it is probably a submodule
+if (fs.lstatSync(git).isFile()) {
+  // the .git file should contain "gitdir: ../.git/modules/path" if we use submodules
+  var fileContents = fs.readFileSync(git, 'utf8');
+  if (fileContents.match(/^gitdir:/)) {
+    git = path.resolve(root, fileContents.replace(/gitdir: /, '').replace(/^\s+|\s+$/g, ''));
+    hooks = path.resolve(git, 'hooks');
+    precommit = path.resolve(hooks, 'pre-commit');
+  }
+}
+
 //
 // Bail out if we don't have an `.git` directory as the hooks will not get
 // triggered. If we do have directory create a hooks folder if it doesn't exist.
@@ -51,7 +62,6 @@ catch (e) {}
 // as stashing - unstashing the unstaged changes)
 // TODO: we could keep launching the old pre-commit scripts
 var hookRelativeUnixPath = hook.replace(root, '.');
-
 if(os.platform() === 'win32') {
   hookRelativeUnixPath = hookRelativeUnixPath.replace(/[\\\/]+/g, '/');
 }

--- a/uninstall.js
+++ b/uninstall.js
@@ -3,7 +3,21 @@
 var fs = require('fs')
   , path = require('path')
   , exists = fs.existsSync || path.existsSync
-  , precommit = path.resolve(__dirname, '../..', '.git', 'hooks', 'pre-commit');
+  , root = path.resolve(__dirname, '..', '..')
+  , git = path.resolve(root, '.git')
+  , hooks = path.resolve(git, 'hooks')
+  , precommit = path.resolve(hooks, 'pre-commit');
+
+// If the .git is a file it is probably a submodule
+if (fs.lstatSync(git).isFile()) {
+  // the .git file should contain "gitdir: ../.git/modules/path" if we use submodules
+  var fileContents = fs.readFileSync(git, 'utf8');
+  if (fileContents.match(/^gitdir:/)) {
+    git = path.resolve(root, fileContents.replace(/gitdir: /, '').replace(/^\s+|\s+$/g, ''));
+    hooks = path.resolve(git, 'hooks');
+    precommit = path.resolve(hooks, 'pre-commit');
+  }
+}
 
 //
 // Bail out if we don't have pre-commit file, it might be removed manually.


### PR DESCRIPTION
I have run across an issue where my project was a submodule of some other repository. In that case the install script of pre-commit package did not execute properly. I have added handling of this case, by reading file .git in target repository. This file consists of path to the "true" .git folder.