### PR TITLE
Include workaround for magit with explaining note

### DIFF
--- a/install.js
+++ b/install.js
@@ -102,6 +102,7 @@ if(os.platform() === 'win32') {
 }
 
 var precommitContent = '#!/usr/bin/env bash' + os.EOL
+  +  'unset GIT_LITERAL_PATHSPECS # NOTE: workaround for magit https://magit.vc/manual/magit/My-Git-hooks-work-on-the-command_002dline-but-not-inside-Magit.html ' + os.EOL 
   +  hookRelativeUnixPath + os.EOL
   + 'RESULT=$?' + os.EOL
   + '[ $RESULT -ne 0 ] && exit 1' + os.EOL


### PR DESCRIPTION
Hey this fixes something that has been a slightly bothersome problem for me, and I haven't seen  any reason to believe it would cause regressions for other users but I'm not sure how to be sure. 

Without this "fix", magit (git interface in emacs) encounters the following error `GitError! pathspec ':/' did not match any file(s) known to git` 

I do not really understand why, but [this](https://magit.vc/manual/magit/My-Git-hooks-work-on-the-command_002dline-but-not-inside-Magit.html) was an accurate description of my issue  and  the proposed fix worked.

Let me know what other sort of QA I can do to verify this won't impact other users!