### PR TITLE
Change permissions on pre-commit file from 777 to 775 so it adheres to CIS 6.1.10

### DIFF
--- a/install.js
+++ b/install.js
@@ -121,10 +121,10 @@ catch (e) {
   console.error('pre-commit:');
 }
 
-try { fs.chmodSync(precommit, '777'); }
+try { fs.chmodSync(precommit, '775'); }
 catch (e) {
   console.error('pre-commit:');
-  console.error('pre-commit: chmod 0777 the pre-commit file in your .git/hooks folder because:');
+  console.error('pre-commit: chmod 0775 the pre-commit file in your .git/hooks folder because:');
   console.error('pre-commit: '+ e.message);
   console.error('pre-commit:');
 }


### PR DESCRIPTION
CIS = Center for Internet Security. See https://www.cisecurity.org/cis-benchmarks/.

This fixes issue https://github.com/observing/pre-commit/issues/160

There is no need for this file to be world writable. It needs to be executable.