### PR TITLE
Add NVM node precedence if available

### DIFF
--- a/hook
+++ b/hook
@@ -18,6 +18,15 @@ if [[ -z "$HAS_NODE" ]]; then
   source_home_file ".bash_profile" || source_home_file ".zshrc" || source_home_file ".bashrc" || true
 fi
 
+[ "$NVM_DIR" = "" ] && export NVM_DIR="$HOME/.nvm"
+if [ -f "$NVM_DIR/nvm.sh" ]; then
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+  nvm install
+  nvm use
+fi
+
+NVMNODE=`nvm which node 2> /dev/null`
 NODE=`which node 2> /dev/null`
 NODEJS=`which nodejs 2> /dev/null`
 IOJS=`which iojs 2> /dev/null`
@@ -27,7 +36,9 @@ BINARY=
 #
 # Figure out which binary we need to use for our script execution.
 #
-if [[ -n "$NODE" ]]; then
+if [[ -n "$NVMNODE" ]]; then
+  BINARY="$NVMNODE"
+elif [[ -n "$NODE" ]]; then
   BINARY="$NODE"
 elif [[ -n "$NODEJS" ]]; then
   BINARY="$NODEJS"
@@ -37,8 +48,12 @@ elif [[ -x "$LOCAL" ]]; then
   BINARY="$LOCAL"
 fi
 
+if [ ! -f "$BINARY" ]; then
+  echo "something wrong: node not exist"
+  exit 1
+fi
 #
-# Add --dry-run cli flag support so we can execute this hook without side effects
+# Add --dry-run cli flag support so we can execute this hook without side affects
 # and see if it works in the current environment
 #
 if [[ $* == *--dry-run* ]]; then


### PR DESCRIPTION
# Feature
This PR makes use of NVM if it is available first before trying other node binaries. For example if you use a different node version based on your project using `.nvmrc` then the pre-commit hook will automatically pick that up first and use that node version for running the pre-commit commands.

### How to test

1. Create a new project using `npm init` or use an existing project
2. Add a new `.nvmrc` file with the desired node version for example `18.16.0` you can use the following command:
`echo 18.16.0 > .nvmrc`
3. Install pre-commit `npm i pre-commit -D` 
4. Navigate to the `node_modules/pre-commit` folder and edit the `hook` file and add the following contents

```bash
#!/usr/bin/env bash

HAS_NODE=`which node 2> /dev/null || which nodejs 2> /dev/null || which iojs 2> /dev/null`

#
# There are some issues with Source Tree because paths are not set correctly for
# the given environment. Sourcing the bash_profile seems to resolve this for bash users,
# sourcing the zshrc for zshell users.
#
# https://answers.atlassian.com/questions/140339/sourcetree-hook-failing-because-paths-don-t-seem-to-be-set-correctly
#
function source_home_file {
  file="$HOME/$1"
  [[ -f "${file}" ]] && source "${file}"
}

if [[ -z "$HAS_NODE" ]]; then
  source_home_file ".bash_profile" || source_home_file ".zshrc" || source_home_file ".bashrc" || true
fi

[ "$NVM_DIR" = "" ] && export NVM_DIR="$HOME/.nvm"
if [ -f "$NVM_DIR/nvm.sh" ]; then
  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
  nvm install
  nvm use
fi

NVMNODE=`nvm which node 2> /dev/null`
NODE=`which node 2> /dev/null`
NODEJS=`which nodejs 2> /dev/null`
IOJS=`which iojs 2> /dev/null`
LOCAL="/usr/local/bin/node"
BINARY=

#
# Figure out which binary we need to use for our script execution.
#
if [[ -n "$NVMNODE" ]]; then
  BINARY="$NVMNODE"
elif [[ -n "$NODE" ]]; then
  BINARY="$NODE"
elif [[ -n "$NODEJS" ]]; then
  BINARY="$NODEJS"
elif [[ -n "$IOJS" ]]; then
  BINARY="$IOJS"
elif [[ -x "$LOCAL" ]]; then
  BINARY="$LOCAL"
fi

if [ ! -f "$BINARY" ]; then
  echo "something wrong: node not exist"
  exit 1
fi
#
# Add --dry-run cli flag support so we can execute this hook without side affects
# and see if it works in the current environment
#
if [[ $* == *--dry-run* ]]; then
  if [[ -z "$BINARY" ]]; then
    exit 1
  fi
else
  "$BINARY" "$("$BINARY" -e "console.log(require.resolve('pre-commit'))")"
fi
```

Add pre-commit hooks to your `package.json` file as per the Readme of the repo and it should use your desired node version.