### PR TITLE
upgrade cross-spawn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/observing/pre-commit",
   "license": "MIT",
   "dependencies": {
-    "cross-spawn": "^5.0.1",
+    "cross-spawn": "^7.0.6",
     "spawn-sync": "^1.0.15",
     "which": "1.2.x"
   },


### PR DESCRIPTION
## This PR upgrades the cross-spawn from version 5.0.1 to 7.0.6.

##Reason for Upgrade
 Versions of the package cross-spawn before 7.0.5 are vulnerable to Regular Expression Denial of Service (ReDoS) due to 
 improper input sanitization. An attacker can increase the CPU usage and crash the program by crafting a very large and well 
 crafted string.

##Changes Made
Updated package.json

##Linked Issues
Fixes #167 




